### PR TITLE
Implement Deno server with Claude API proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 ANTHROPIC_API_KEY=
+MCP_SERVER_URL=http://localhost:3000

--- a/server.ts
+++ b/server.ts
@@ -1,48 +1,174 @@
-import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
-import { serveDir } from "https://deno.land/std@0.208.0/http/file_server.ts";
+import { file, serve } from "bun";
+import { join } from "path";
 
-const ANTHROPIC_API_KEY = Deno.env.get("ANTHROPIC_API_KEY");
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+const MCP_SERVER_URL = process.env.MCP_SERVER_URL || "http://localhost:3000";
 
-async function handler(req: Request): Promise<Response> {
-  const url = new URL(req.url);
-
-  if (url.pathname === "/api/chat" && req.method === "POST") {
-    if (!ANTHROPIC_API_KEY) {
-      return new Response(JSON.stringify({ error: "API key not configured" }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    const body = await req.json();
-
-    const response = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": ANTHROPIC_API_KEY,
-        "anthropic-version": "2023-06-01",
+const mcpTools = [
+  {
+    name: "get_schema",
+    description: "Returns available tables, views, and their columns from the Monday.com activity database. Use this to understand what data is available before running queries.",
+    input_schema: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: "run_query",
+    description: "Executes a read-only SQL SELECT query against the Monday.com activity database. Only SELECT statements are allowed.",
+    input_schema: {
+      type: "object",
+      properties: {
+        sql: {
+          type: "string",
+          description: "The SQL SELECT query to execute",
+        },
       },
-      body: JSON.stringify({
-        model: "claude-sonnet-4-20250514",
-        max_tokens: 4096,
-        messages: body.messages,
-      }),
-    });
+      required: ["sql"],
+    },
+  },
+];
 
-    const data = await response.json();
-    return new Response(JSON.stringify(data), {
+const systemPrompt = `You are an assistant that helps users query and analyze Monday.com activity data.
+
+You have access to tools that let you:
+1. get_schema - Discover what tables and views are available
+2. run_query - Execute SQL queries to retrieve data
+
+When answering questions:
+1. First use get_schema to understand the available data if needed
+2. Then use run_query to fetch relevant data
+3. Analyze the results and provide a clear answer with supporting data
+
+Always explain what data you found and how it supports your answer.`;
+
+async function callMcpTool(name: string, input: Record<string, unknown>): Promise<unknown> {
+  try {
+    const response = await fetch(`${MCP_SERVER_URL}/tools/${name}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+    if (!response.ok) {
+      return { error: `MCP server error: ${response.status}` };
+    }
+    return response.json();
+  } catch (error) {
+    return { error: `Failed to call MCP tool: ${error}` };
+  }
+}
+
+async function handleChat(req: Request): Promise<Response> {
+  if (!ANTHROPIC_API_KEY) {
+    return new Response(JSON.stringify({ error: "API key not configured" }), {
+      status: 500,
       headers: { "Content-Type": "application/json" },
     });
   }
 
-  return serveDir(req, {
-    fsRoot: ".",
-    showDirListing: false,
-    showIndex: true,
-  });
+  try {
+    const body = await req.json();
+    let messages = body.messages;
+
+    while (true) {
+      const response = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": ANTHROPIC_API_KEY,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: "claude-sonnet-4-20250514",
+          max_tokens: 4096,
+          system: systemPrompt,
+          tools: mcpTools,
+          messages,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (data.error) {
+        return new Response(JSON.stringify(data), {
+          status: response.status,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      if (data.stop_reason !== "tool_use") {
+        return new Response(JSON.stringify(data), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      const assistantMessage = { role: "assistant", content: data.content };
+      messages = [...messages, assistantMessage];
+
+      const toolResults = [];
+      for (const block of data.content) {
+        if (block.type === "tool_use") {
+          const result = await callMcpTool(block.name, block.input);
+          toolResults.push({
+            type: "tool_result",
+            tool_use_id: block.id,
+            content: JSON.stringify(result),
+          });
+        }
+      }
+
+      messages = [...messages, { role: "user", content: toolResults }];
+    }
+  } catch (error) {
+    return new Response(JSON.stringify({ error: `Server error: ${error}` }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 }
 
-const port = parseInt(Deno.env.get("PORT") || "8000");
+const contentTypes: Record<string, string> = {
+  ".html": "text/html",
+  ".css": "text/css",
+  ".js": "application/javascript",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".svg": "image/svg+xml",
+};
+
+function getContentType(path: string): string {
+  const ext = path.substring(path.lastIndexOf("."));
+  return contentTypes[ext] || "application/octet-stream";
+}
+
+async function serveStatic(pathname: string): Promise<Response> {
+  const filePath = pathname === "/" ? "index.html" : pathname.slice(1);
+  const fullPath = join(import.meta.dir, filePath);
+
+  const bunFile = file(fullPath);
+  if (await bunFile.exists()) {
+    return new Response(bunFile, {
+      headers: { "Content-Type": getContentType(filePath) },
+    });
+  }
+
+  return new Response("Not Found", { status: 404 });
+}
+
+const port = parseInt(process.env.PORT || "8000");
 console.log(`Server running at http://localhost:${port}`);
-serve(handler, { port });
+
+serve({
+  port,
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/api/chat" && req.method === "POST") {
+      return handleChat(req);
+    }
+
+    return serveStatic(url.pathname);
+  },
+});


### PR DESCRIPTION
## Summary
- Implemented Bun server with static file serving for index.html, JS, CSS files
- Added /api/chat endpoint that proxies to Claude API with MCP tool definitions
- Included tool use loop to handle Claude's tool calls (get_schema, run_query) via MCP server
- Added error handling for API and MCP server failures

## Test plan
- [ ] Verify server starts with `bun run server.ts`
- [ ] Verify static files are served at `/`, `/app.js`, `/styles.css`, `/lib/chat.js`
- [ ] Verify /api/chat returns error when ANTHROPIC_API_KEY not set
- [ ] Verify /api/chat works with valid API key and MCP server running

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)