### PR TITLE
Implement MCP server integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Monday Activity Chat
+
+Chat interface for querying Monday.com activity data via AI and MCP tools.
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) runtime
+- [monday-activity-mcp](https://github.com/pel-sites/monday-activity-mcp) server
+
+## Setup
+
+1. Clone and set up the MCP server:
+```bash
+git clone https://github.com/pel-sites/monday-activity-mcp
+cd monday-activity-mcp
+npm install
+./scripts/fetch-db.sh
+npm start  # Runs on port 3000
+```
+
+2. Configure this project:
+```bash
+cp .env.example .env
+# Edit .env and add your ANTHROPIC_API_KEY
+```
+
+3. Start the chat frontend:
+```bash
+bun run server.ts  # Runs on port 8000
+```
+
+4. Open http://localhost:8000
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ANTHROPIC_API_KEY` | Claude API key (required) | - |
+| `MCP_SERVER_URL` | MCP server endpoint | `http://localhost:3000` |
+| `PORT` | Frontend server port | `8000` |
+
+## MCP Tools
+
+The chat uses these tools from the MCP server:
+
+- **get_schema** - Returns available tables and views
+- **run_query** - Executes read-only SQL queries
+- **get_user_metrics** - Returns user metrics with rankings

--- a/server.ts
+++ b/server.ts
@@ -28,6 +28,15 @@ const mcpTools = [
       required: ["sql"],
     },
   },
+  {
+    name: "get_user_metrics",
+    description: "Returns comparative metrics for all users with rankings. Includes total_actions, items_created, days_active, workspaces_touched, boards_touched and their rankings across users.",
+    input_schema: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+  },
 ];
 
 const systemPrompt = `You are an assistant that helps users query and analyze Monday.com activity data.
@@ -35,11 +44,16 @@ const systemPrompt = `You are an assistant that helps users query and analyze Mo
 You have access to tools that let you:
 1. get_schema - Discover what tables and views are available
 2. run_query - Execute SQL queries to retrieve data
+3. get_user_metrics - Get comparative metrics and rankings for all users
 
 When answering questions:
 1. First use get_schema to understand the available data if needed
-2. Then use run_query to fetch relevant data
+2. Use run_query to fetch relevant data, or get_user_metrics for user comparisons
 3. Analyze the results and provide a clear answer with supporting data
+
+Format your responses with:
+**Answer**: Direct response to the question
+**Justification**: The data and metrics that support your answer
 
 Always explain what data you found and how it supports your answer.`;
 


### PR DESCRIPTION
## Summary
- Add `get_user_metrics` tool schema to complete MCP tool definitions
- Update system prompt to reference all three MCP tools and guide response formatting
- Add README with setup instructions for running MCP server alongside frontend

Closes #5

## Test plan
- [ ] Start MCP server on port 3000
- [ ] Start frontend server with `bun run server.ts`
- [ ] Test chat queries that use get_schema, run_query, and get_user_metrics tools
- [ ] Verify tool responses are fed back to Claude and interpreted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)